### PR TITLE
Use relative xpath query for select_* methods

### DIFF
--- a/WebDriver/WebElement.php
+++ b/WebDriver/WebElement.php
@@ -222,16 +222,16 @@ class WebDriver_WebElement {
    */
 
   public function select_label($label) {
-    $this->get_next_element("//option[text()=" . WebDriver::QuoteXPath($label) . "]")->select();
+    $this->get_next_element("xpath=option[text()=" . WebDriver::QuoteXPath($label) . "]")->select();
   }
   
   public function select_value($value) {
-    $this->get_next_element("//option[@value=" . WebDriver::QuoteXPath($value) . "]")->select();
+    $this->get_next_element("xpath=option[@value=" . WebDriver::QuoteXPath($value) . "]")->select();
   }
   
   // 1-based index
   public function select_index($index) {
-    $this->get_next_element("//option[" . $index . "]")->select();
+    $this->get_next_element("xpath=option[" . $index . "]")->select();
   }
   
   public function select_random() {


### PR DESCRIPTION
Because of the way Selenium server behaves, it's better to use relative xpath queries for the select_\* methods. Whatever you pass as an xpath query to find child element will be read as-is.

See http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/element
