### PR TITLE
Error selecting frame by name

### DIFF
--- a/WebDriver/Driver.php
+++ b/WebDriver/Driver.php
@@ -371,6 +371,8 @@ class WebDriver_Driver {
   public function select_frame($identifier = null) {
     if ($identifier !== null) {
       $this->get_element($identifier); // POST /session/:sessionId/frame does not use implicit wait but POST /session/:sessionId/element does
+      $locator = WebDriver::ParseLocator($identifier);
+      $identifier = $locator['value'];
     }
     $payload = array("id" => $identifier);
     $this->execute("POST", "/session/:sessionId/frame", $payload);


### PR DESCRIPTION
I'm testing a webapp (most of which I can't change) which uses frame which have name attributes but no id attribute.

If I try to select the frame by name using this code:

``` PHP
$this->driver->select_frame("content");
```

it will produce the following error:

<pre>Unsuccessful WebDriver command: 7 - NoSuchElement - An element could not be located on the page using the given search parameters.
Command: POST - http://localhost:4444/wd/hub/session/1329229716776/element - {"using":"id","value":"content"}
Message: Unable to locate element: {"method":"id","selector":"content"}
Command duration or timeout: 5.06 seconds
For documentation on this error, please visit: http://seleniumhq.org/exceptions/no_such_element.html
Build info: version: '2.18.0', revision: '15704', time: '2012-01-27 15:48:16'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '2.6.31-gentoo-r10', java.version: '1.6.0_24'
Driver info: driver.version: EventFiringWebDriver
Failed asserting that <integer:7> matches expected <integer:0>.</pre>


This is due to select_frame calling get_element first if an identifier is passed.

To get round this problem I modified select_frame so that it would work if the identifier was passed as "name=content".
