### PR TITLE
Fixes to work with PHPUnit 3.6 and PHP 5.3

### DIFF
--- a/WebDriver.php
+++ b/WebDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once 'WebDriver/Exception.php';
+
 class WebDriver {
   public static $ImplicitWaitMS = 0;
   
@@ -68,7 +70,7 @@ class WebDriver {
     if (isset(self::$keys[$name])) {
       return json_decode('"' . self::$keys[$name] . '"');
     } else {
-      throw new Exception("Can't type key $name");
+      throw new WebDriver_Exception("Can't type key $name");
     }
   }
 
@@ -131,7 +133,7 @@ class WebDriver {
         $strategy = "xpath";
         $value = $locator;
       } else if (substr($locator, 0, 9) === "document." || substr($locator, 0, 4) === "dom=") {
-        throw new Exception("DOM selectors aren't supported in WebDriver: $locator");
+        throw new WebDriver_Exception("DOM selectors aren't supported in WebDriver: $locator");
       } else { // Fall back to id
         $strategy = "id";
         $value = $locator;
@@ -148,7 +150,7 @@ class WebDriver {
     } else if (!$contains_double_quote) {
       return '"' . $value . '"';
     } else {
-      $parts = split("'", $value);
+      $parts = preg_split("/'/", $value);
       return "concat('" . implode("', \"'\", '", $parts) . "')";
     }
   }
@@ -175,6 +177,7 @@ class WebDriver {
       'teal' => '008080',
       'aqua' => '00FFFF',
     );
+    $six_hex = null;
     if (preg_match('/^rgb\(([0-9]+),\s*([0-9]+),\s*([0-9]+)\)$/', $color, $rgb)) {
       // rgb(255, 255, 255) -> ffffff
       if (0 <= $rgb[1] && $rgb[1] <= 255 && 0 <= $rgb[2] && $rgb[2] <= 255 && 0 <= $rgb[3] && $rgb[3] <= 255) {

--- a/WebDriver/Exception.php
+++ b/WebDriver/Exception.php
@@ -1,0 +1,5 @@
+<?php
+
+class WebDriver_Exception extends Exception
+{
+}

--- a/WebDriverColorTest.php
+++ b/WebDriverColorTest.php
@@ -39,7 +39,7 @@ class WebDriverColorTest extends PHPUnit_Framework_TestCase {
   
   /**
    * @dataProvider invalid_colors
-   * @expectedException Exception
+   * @expectedException PHPUnit_Framework_ExpectationFailedException
    */
   public function test_invalid_colors($input) {
     WebDriver::CanonicalizeCSSColor($input);

--- a/WebDriverSelectorTest.php
+++ b/WebDriverSelectorTest.php
@@ -62,7 +62,7 @@ class WebDriverSelectorTest extends PHPUnit_Framework_TestCase {
   
   /**
    * @dataProvider invalid_selectors
-   * @expectedException Exception
+   * @expectedException WebDriver_Exception
    */
   public function test_invalid_selectors($input) {
     WebDriver::ParseLocator($input);

--- a/WebDriverXPathTest.php
+++ b/WebDriverXPathTest.php
@@ -20,7 +20,7 @@ consecutive''''quotes
 consecutive""""quotes
 consecutive'"'"'mixedquotes
 EOT;
-    $test_data = split("\n", $strings);
+    $test_data = preg_split("/\n/", $strings);
     foreach ($test_data as &$data) {
       $data = array($data);
     }


### PR DESCRIPTION
- Throw/Expect new WebDriver_Exception instead of Exception
- Add default $six_hex value of null to eliminate warnings
  (which become exceptions in PHPUnit's error handling)
- Use preg_split() instead of the deprecated split() to eliminate
  deperecation warnings
- Expect PHPUnit_Framework_ExpectationFailedException when appropriate
