### PR TITLE
Fix for issue #26

### DIFF
--- a/WebDriver/Driver.php
+++ b/WebDriver/Driver.php
@@ -39,7 +39,7 @@ class WebDriver_Driver {
     $response = $this->execute("POST", "/session", $payload);
     
     // Parse out session id
-    preg_match("/\nLocation:.*\/(.*)\n/", $response['header'], $matches);
+    preg_match("/\nLocation:.*\/(.*)\n/", $response['header'] . "\n", $matches);
     if (!empty($response['body'])) {
       $additional_info = $response['body'];
     } else if (!empty($response['header'])) {


### PR DESCRIPTION
parsing out session id failed in case Location header was not followed by \n
