### PR TITLE
Adds Composer Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "chibimagic/webdriver-php",
+    "type": "library",
+    "description": "PHP bindings for WebDriver (Selenium 2 API).",
+    "keywords": [
+        "Selenium 2",
+        "WebDriver"
+    ],
+    "autoload": {
+        "psr-0": {
+            "WebDriver": ""
+        }
+    }
+}
+


### PR DESCRIPTION
Adds a composer.json file to support installing WebDriver-PHP as a dependency through Composer.

Composer uses simple json files to declare requirements and dependencies of a project. This makes it easier for new team members to get projects setup with all correct dependencies setup with the right versions. For more information, see http://getcomposer.org/.
